### PR TITLE
Refactor: toggleLock function to remove else if statement

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -127,11 +127,7 @@ function toggleLock(event) {
   var palKeys = Object.keys(currentPalette);
   var targetLock = event.target.nextElementSibling.children[1];
   for (var i = 1; i < palVals.length; i++) {
-    if (palKeys[i] === boxId && !palVals[i].locked) {
-      changeIcon(targetLock);
-      currentPalette.switchLocked(palKeys[i]);
-      break;
-    } else if (palKeys[i] === boxId && palVals[i].locked) {
+    if (palKeys[i] === boxId) {
       changeIcon(targetLock);
       currentPalette.switchLocked(palKeys[i]);
       break;


### PR DESCRIPTION
Hey y'all!

I noticed that our `toggleLock()` function didn't need the `else if ()` statement anymore because we switched the logic of `changeIcon()` and `switchLocked()`, so there was no need to check for any other condition - we're doing that within the other functions. 

I refactored `toggleLock()` to remove the `else if ()` statement. 

Let me know if you have any questions!

J